### PR TITLE
Fix encoding empty attributes ("") that were being encoded to "null" instead of ""

### DIFF
--- a/library/src/main/java/com/apk/axml/utils/AttrChunk.java
+++ b/library/src/main/java/com/apk/axml/utils/AttrChunk.java
@@ -25,7 +25,7 @@ public class AttrChunk extends Chunk<Chunk.EmptyHeader> {
 
     @Override
     public void writeEx(IntWriter w) throws IOException {
-        w.write(startTagChunk.stringIndex(null,namespace));
+        w.write(startTagChunk.stringIndex(null, TextUtils.isEmpty(namespace) ? null : namespace));
         w.write(startTagChunk.stringIndex(namespace,name));
         if (value.type == 0x03)
             w.write(startTagChunk.stringIndex(null,rawValue));

--- a/library/src/main/java/com/apk/axml/utils/StringPoolChunk.java
+++ b/library/src/main/java/com/apk/axml/utils/StringPoolChunk.java
@@ -214,12 +214,13 @@ public class StringPoolChunk extends Chunk<StringPoolChunk.H> {
     public int stringIndex(String namespace, String s) {
         namespace = preHandleString(namespace);
         s = preHandleString(s);
-        if (TextUtils.isEmpty(s)) return -1;
+        if (s == null) return -1;
         int l=rawStrings.size();
         for (int i=0; i<l; ++i) {
             StringItem item = rawStrings.get(i).origin;
             if (s.equals(item.string)&&(TextUtils.isEmpty(namespace)||namespace.equals(item.namespace))) return i;
         }
+        if (TextUtils.isEmpty(s)) return -1;
         throw new RuntimeException("String: '"+s+"' not found");
     }
 


### PR DESCRIPTION
There is one more problem, when encoding AndroidManifest.xml files that contain an empty value (eg. android:taskAffinity=""), it saves without any error. However, empty attributes ("") will be encoded to "null" instead of "", which is invalid; the APK won't install and the icon will be blank.
[Example video](https://t.me/exceptorIo/14)
I noticed the old axml2xml doesn't have this problem so I checked and found the issue seems to be caused by some changes in the StringPoolChunk and AttrChunk classes in how empty values are handled.